### PR TITLE
fix: handle empty delete responses

### DIFF
--- a/src/endpoints/payment-in/payment-in.test.ts
+++ b/src/endpoints/payment-in/payment-in.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createFetchMock, expectFetch, moysklad } from "../../../test-utils"
+import { MoyskladApiError } from "../../errors"
 import { Entity } from "../../types/entity"
 import { MediaType } from "../../types/media-type"
 
@@ -280,6 +281,85 @@ describe("paymentIn", () => {
         method: "DELETE",
       })
     })
+
+    it("resolves undefined for an empty 200 response", async () => {
+      const fetchMock = createFetchMock()
+      const id = "5427bc76-b95f-11eb-0a80-04bb000cd583"
+      fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+
+      await expect(moysklad.paymentIn.delete(id)).resolves.toBeUndefined()
+
+      await expectFetch({
+        fetchMock,
+        url: `/entity/paymentin/${id}`,
+        method: "DELETE",
+      })
+    })
+
+    it("resolves undefined for a 204 response", async () => {
+      const fetchMock = createFetchMock()
+      const id = "5427bc76-b95f-11eb-0a80-04bb000cd583"
+      fetchMock.mockResolvedValue(new Response(null, { status: 204 }))
+
+      await expect(moysklad.paymentIn.delete(id)).resolves.toBeUndefined()
+
+      await expectFetch({
+        fetchMock,
+        url: `/entity/paymentin/${id}`,
+        method: "DELETE",
+      })
+    })
+
+    it("discards a successful response body", async () => {
+      const fetchMock = createFetchMock()
+      const id = "5427bc76-b95f-11eb-0a80-04bb000cd583"
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ deleted: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+
+      await expect(moysklad.paymentIn.delete(id)).resolves.toBeUndefined()
+
+      await expectFetch({
+        fetchMock,
+        url: `/entity/paymentin/${id}`,
+        method: "DELETE",
+      })
+    })
+
+    it("preserves a JSON API error", async () => {
+      const fetchMock = createFetchMock()
+      const id = "5427bc76-b95f-11eb-0a80-04bb000cd583"
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            errors: [
+              {
+                code: 404,
+                error: "Payment in not found",
+              },
+            ],
+          }),
+          {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+
+      const deletion = moysklad.paymentIn.delete(id)
+
+      await expect(deletion).rejects.toBeInstanceOf(MoyskladApiError)
+      await expect(deletion).rejects.toMatchObject({ code: 404 })
+
+      await expectFetch({
+        fetchMock,
+        url: `/entity/paymentin/${id}`,
+        method: "DELETE",
+      })
+    })
   })
 
   describe("update", () => {
@@ -456,6 +536,20 @@ describe("paymentIn", () => {
       const id = "5427bc76-b95f-11eb-0a80-04bb000cd583"
 
       await moysklad.paymentIn.trash(id)
+
+      await expectFetch({
+        fetchMock,
+        url: `/entity/paymentin/${id}/trash`,
+        method: "POST",
+      })
+    })
+
+    it("resolves undefined for an empty response", async () => {
+      const fetchMock = createFetchMock()
+      const id = "5427bc76-b95f-11eb-0a80-04bb000cd583"
+      fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+
+      await expect(moysklad.paymentIn.trash(id)).resolves.toBeUndefined()
 
       await expectFetch({
         fetchMock,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -177,9 +177,7 @@ export const createMoysklad = (options: ApiClientOptions): Moysklad => {
       if (method === "delete") {
         const id = callbackOptions.args[0] as string
 
-        return client
-          .delete(`${path}/${id}`)
-          .then((response) => response.json())
+        return client.delete(`${path}/${id}`).then((): void => undefined)
       }
 
       if (method === "batchDelete") {
@@ -202,9 +200,7 @@ export const createMoysklad = (options: ApiClientOptions): Moysklad => {
       if (method === "trash") {
         const id = callbackOptions.args[0] as string
 
-        return client
-          .post(`${path}/${id}/trash`)
-          .then((response) => response.json())
+        return client.post(`${path}/${id}/trash`).then((): void => undefined)
       }
 
       if (method === "upsert" || method === "create") {


### PR DESCRIPTION
## Summary

- Resolve generic entity `delete()` and `trash()` calls to `undefined` without parsing successful response bodies.
- Preserve existing non-2xx error handling and JSON-returning methods.
- Add locked regression tests for empty responses, successful response bodies, API errors, and request paths.

## Verification

- Red phase: 4 expected failures before the proxy change; API-error characterization passed.
- `bun check`
- `bun typecheck`
- `bun run test` (593 tests passed)
- Test checksum remained `e7d3d45c3f4243e8023e34be1710788625c1d80e81cf21b4cc4ee1fd850f367a`.